### PR TITLE
Set overflow  property when height auto.

### DIFF
--- a/src/AnimateHeight.elm
+++ b/src/AnimateHeight.elm
@@ -719,6 +719,14 @@ container (Config config) =
 
             else
                 []
+
+        resolveOverflow =
+            case state_.calculatedHeight of
+                Internal.Auto ->
+                    [ style "overflow" "visible" ]
+
+                _ ->
+                    []
     in
     div
         ([ id id_
@@ -732,6 +740,7 @@ container (Config config) =
             ++ resolveAnimationPlayState
             ++ resolveTransitionDuration
             ++ resolveTiming
+            ++ resolveOverflow
         )
         [ div
             ([ style "transition-property" "opacity"


### PR DESCRIPTION
Addresses #13 

# Context
The overflow property by default is set to `hidden`, because when we start with a default container we have a height set at `0px`. If the overflow property wasn't set to `hidden` then we would see the content.

When animating to a height of `auto` it makes sense to allow any overflowed elements to be visible once the animation has ended. Things such as absolutely positioned menus etc can now be visible without being clipped by the container.